### PR TITLE
Fix team select bug

### DIFF
--- a/lib/pages/scout/select_match.dart
+++ b/lib/pages/scout/select_match.dart
@@ -162,7 +162,7 @@ class TeamSelectDialog extends StatelessWidget {
                 MaterialPageRoute(
                   builder: (context) => MatchScoutPage(
                     match: match,
-                    team: match.blue[i],
+                    team: match.red[i],
                   ),
                 ),
               ),


### PR DESCRIPTION
Fixed a bug which only allowed a blue alliance team (regardless of the team chosen) to be selected when choosing a match to scout